### PR TITLE
[DONE] ロード画面アニメーション作成 & 再スタートモーダル

### DIFF
--- a/src/components/FailtoMatchModal.css
+++ b/src/components/FailtoMatchModal.css
@@ -1,0 +1,11 @@
+.modal-content-fullscreen {
+  background-color: #fefefe;
+  border-radius: 6px;
+  box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.2);
+  height: auto;
+  margin: 5%;
+  margin-top: 30%;
+  padding: 5%;
+  position: fixed;
+  width: 80%;
+}

--- a/src/components/FailtoMatchModal.js
+++ b/src/components/FailtoMatchModal.js
@@ -1,0 +1,26 @@
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+
+import './FailtoMatchModal.css';
+
+class FailtoMatchModal extends Component {
+  render() {
+    console.log('User token:', window.USER_TOKEN);
+
+    return (
+      <div className="modal" id="failtoMatchModal" style={{ display: 'block' }}>
+        <div className="modal-content-fullscreen fail-to-match__modal">
+          <h2>マッチングできませんでした。</h2>
+          <button className="text-btn single-line-btn">再ロードする</button>
+          <Link to="/search">
+            <button className="text-btn single-line-btn minor-btn">
+              サーチ画面に戻る
+            </button>
+          </Link>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default FailtoMatchModal;

--- a/src/containers/ZeroCrasherLoading.css
+++ b/src/containers/ZeroCrasherLoading.css
@@ -1,0 +1,25 @@
+.loading-indicator {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 80vh;
+}
+
+.loader {
+  border: 16px solid #f3f3f3;
+  border-top: 16px solid #448c80;
+  border-radius: 50%;
+  width: 80px;
+  height: 80px;
+  animation: spin 2s ease-in-out infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(45deg);
+  }
+  100% {
+    transform: rotate(405deg);
+  }
+}

--- a/src/containers/ZeroCrasherLoading.js
+++ b/src/containers/ZeroCrasherLoading.js
@@ -1,8 +1,19 @@
 import React, { Component } from 'react';
 
+import './ZeroCrasherLoading.css';
+import FailtoMatchModal from '../components/FailtoMatchModal';
+
 class ZeroCrasherLoading extends Component {
   render() {
-    return <div>相性トーク：ロード画面</div>;
+    return (
+      <div>
+        <div className="loading-indicator">
+          <h3>マッチング中...</h3>
+          <div className="loader" />
+        </div>
+        <FailtoMatchModal />
+      </div>
+    );
   }
 }
 


### PR DESCRIPTION
- [x] ロード画面の CSS アニメーション（`/containers/ZeroCrasherLoading.js` & `/containers/ZeroCrasherLoading.css`）
- [x] 再スタートモーダル（`/components/FailtoMatchModal.js` & `/components/FailtoMatchModal.css`）
  - [x] `再ロード` ボタン（仕様がよくわからないので、とりあえず空のボタンにします）
  - [x] `ホームに戻る` ボタン（`/search` に戻る）

*NOTE*: モーダルがロードアニメーションの前にあるので、モーダル（`id="failtoMatchModal"` の `<div>` ）の CSS property を `display: block;` から `display: none;` に変えれば背後のロードアニメーションが見れます。