### PR TITLE
[DONE] ロード画面デザイン & 再マッチング開始モーダルデザイン実装

### DIFF
--- a/src/components/FailtoMatchModal.js
+++ b/src/components/FailtoMatchModal.js
@@ -5,15 +5,13 @@ import './FailtoMatchModal.css';
 
 class FailtoMatchModal extends Component {
   render() {
-    console.log('User token:', window.USER_TOKEN);
-
     return (
-      <div className="modal" id="failtoMatchModal" style={{ display: 'block' }}>
+      <div className="modal" id="failtoMatchModal" style={{ display: 'none' }}>
         <div className="modal-content-fullscreen fail-to-match__modal">
           <h2>マッチングできませんでした。</h2>
           <button className="text-btn single-line-btn">再ロードする</button>
           <Link to="/search">
-            <button className="text-btn single-line-btn minor-btn">
+            <button className="text-btn single-line-btn">
               サーチ画面に戻る
             </button>
           </Link>

--- a/src/containers/ZeroCrasherLoading.css
+++ b/src/containers/ZeroCrasherLoading.css
@@ -1,25 +1,47 @@
 .loading-indicator {
+  color: #4a4a4a;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 80vh;
+  height: 100vh;
 }
 
 .loader {
-  border: 16px solid #f3f3f3;
-  border-top: 16px solid #448c80;
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #75d0d4;
   border-radius: 50%;
-  width: 80px;
-  height: 80px;
-  animation: spin 2s ease-in-out infinite;
+  height: 60px;
+  margin-bottom: 20px;
+  width: 60px;
+  animation: spin 1s linear infinite;
+}
+
+.crasher-loading__button-holder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 60px;
+}
+
+.crasher-loading__cancle-button {
+  background-color: #ffffff;
+  border: 1px solid #75d0d4;
+  border-radius: 100px;
+  color: #75d0d4;
+  cursor: pointer;
+  padding: 12px 30px 12px 30px;
+}
+
+.crasher-loading__cancle-button a {
+  color: #75d0d4;
 }
 
 @keyframes spin {
   0% {
-    transform: rotate(45deg);
+    transform: rotate(0deg);
   }
   100% {
-    transform: rotate(405deg);
+    transform: rotate(360deg);
   }
 }

--- a/src/containers/ZeroCrasherLoading.js
+++ b/src/containers/ZeroCrasherLoading.js
@@ -1,15 +1,23 @@
 import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
 
 import './ZeroCrasherLoading.css';
 import FailtoMatchModal from '../components/FailtoMatchModal';
+import Header from '../components/Header';
 
 class ZeroCrasherLoading extends Component {
   render() {
     return (
       <div>
+        <Header currentPage="ランダムトーク" />
         <div className="loading-indicator">
-          <h3>マッチング中...</h3>
           <div className="loader" />
+          <h4>マッチング相手を探しています</h4>
+          <div className="crasher-loading__button-holder">
+            <button className="crasher-loading__cancle-button">
+              <Link to="/zero-crasher/tutorial">キャンセル</Link>
+            </button>
+          </div>
         </div>
         <FailtoMatchModal />
       </div>


### PR DESCRIPTION
- [x] ローディング動画
- [x] 「キャンセル」ボタン & `/zero-crasher/tutorial` へリンク

*NOTE*: 再マッチング開始モーダル（`/containers/FailtoMatchModal.js`）はデザインがないため（多分今回には優先順位もそんな高くないはず）、デザインの実装をしていません。