### PR TITLE
[DONE] 相性トーク終了時のモーダルデザイン実装

### DIFF
--- a/src/components/TalkOverModal.css
+++ b/src/components/TalkOverModal.css
@@ -1,6 +1,6 @@
 .modal-content-fullscreen {
   background-color: #fefefe;
-  border-radius: 6px;
+  border-radius: 12px;
   box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.2);
   height: auto;
   margin: 5%;
@@ -8,4 +8,40 @@
   padding: 5%;
   position: fixed;
   width: 80%;
+}
+
+.talk-over-modal__counter {
+  color: #fe727d;
+}
+
+.talk-over-modal__like-button {
+  background-image: linear-gradient(to right, #ff9699, #fe6f7a);
+  border: none;
+  border-radius: 100px;
+  color: #ffffff;
+  cursor: pointer;
+  font-size: 14px;
+  margin: 12px 30px 12px 30px;
+  width: 90%;
+  padding: 16px;
+}
+
+.talk-over-modal__liked-button {
+  background-image: linear-gradient(to right, #ffac51, #ff9643);
+}
+
+.talk-ver-modal__inline-icon {
+  width: 13px;
+  margin-right: 6px;
+}
+
+.talk-over-modal__home-link {
+  color: #75d0d4;
+  font-size: 13px;
+}
+
+.time-up-modal__button-contaier {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }

--- a/src/components/TalkOverModal.js
+++ b/src/components/TalkOverModal.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 
 import './TalkOverModal.css';
+import likeIcon from '../images/like-btn-white.svg';
 
 class TalkOverModal extends Component {
   state = {
@@ -17,17 +18,30 @@ class TalkOverModal extends Component {
     let likeButton = null;
     if (!this.state.isLiked) {
       likeButton = (
-        <button className="text-btn single-line-btn" onClick={this.handleLike}>
-          いいね！
+        <button
+          className="talk-over-modal__like-button"
+          onClick={this.handleLike}
+        >
+          <img
+            src={likeIcon}
+            alt="Like Icon"
+            className="inline-icon talk-ver-modal__inline-icon"
+          />
+          <span>いいね！</span>
         </button>
       );
     } else {
       likeButton = (
         <button
-          className="text-btn single-line-btn minor-btn"
+          className="talk-over-modal__like-button talk-over-modal__liked-button"
           onClick={this.handleLike}
         >
-          いいねしました
+          <img
+            src={likeIcon}
+            alt="Like Icon"
+            className="inline-icon talk-ver-modal__inline-icon"
+          />
+          <span>いいね！しました</span>
         </button>
       );
     }
@@ -35,14 +49,20 @@ class TalkOverModal extends Component {
     return (
       <div className="modal" id="talkOverModal" style={{ display: 'block' }}>
         <div className="modal-content-fullscreen fail-to-match__modal">
-          <h2>終了しました</h2>
-          <p>相手が気になった場合は「いいね」を押してみましょう！</p>
-          {likeButton}
-          <Link to="/search">
-            <button className="text-btn single-line-btn minor-btn">
-              サーチ画面に戻る
-            </button>
-          </Link>
+          <h3>タイムアップ</h3>
+          <h1 className="talk-over-modal__counter">0:00</h1>
+          <p>
+            Nipperさんともっと話してみたい！と感じたらいいね！を押しましょう！
+          </p>
+          <div className="time-up-modal__button-contaier">
+            {likeButton}
+            <Link
+              to="/zero-crasher/tutorial"
+              className="talk-over-modal__home-link"
+            >
+              ホームに戻る
+            </Link>
+          </div>
         </div>
       </div>
     );

--- a/src/containers/ZeroCrasher.js
+++ b/src/containers/ZeroCrasher.js
@@ -1,8 +1,14 @@
 import React, { Component } from 'react';
+import TalkOverModal from '../components/TalkOverModal';
 
 class ZeroCrasher extends Component {
   render() {
-    return <div>相性トーク：トークページ</div>;
+    return (
+      <div>
+        <div>相性トーク：トークページ</div>
+        <TalkOverModal />
+      </div>
+    );
   }
 }
 

--- a/src/images/like-btn-white.svg
+++ b/src/images/like-btn-white.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Capa_1" x="0px" y="0px" width="512px" height="512px" viewBox="0 0 561 561" style="enable-background:new 0 0 561 561;" xml:space="preserve">
+<g>
+	<g id="thumb-up">
+		<path d="M0,535.5h102v-306H0V535.5z M561,255c0-28.05-22.95-51-51-51H349.35l25.5-117.3c0-2.55,0-5.1,0-7.65    c0-10.2-5.1-20.4-10.199-28.05L336.6,25.5L168.3,193.8c-10.2,7.65-15.3,20.4-15.3,35.7v255c0,28.05,22.95,51,51,51h229.5    c20.4,0,38.25-12.75,45.9-30.6l76.5-181.051c2.55-5.1,2.55-12.75,2.55-17.85v-51H561C561,257.55,561,255,561,255z" fill="#ffffff"/>
+	</g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+</svg>


### PR DESCRIPTION
- [x] 情報追加
- [x] ボタンスタイル `TalkOverModal.css`

*NOTE*: 「ホームに戻る」のボタンが、システム設計上 `/search/` に飛ばすようにすれば、`/login/` の登録画面に強制的に redirect されます。なので、とりあえず `/zero-crasher/tutorial/` に飛ぶようにしています。